### PR TITLE
feat: reduce graph data cache TTL from 30 days to 6 hours

### DIFF
--- a/config/cache.ts
+++ b/config/cache.ts
@@ -3,7 +3,7 @@
  */
 
 export const CACHE_KEY = "graph-data-3";
-export const CACHE_TTL_SECONDS = 86400 * 30; // 30 days
+export const CACHE_TTL_SECONDS = 3600 * 6; // 6 hours
 
 // Field reports cache
 export const REPORTS_CACHE_KEY = "field-reports-1";


### PR DESCRIPTION
## Description

Reduces the graph data cache TTL from 30 days to 6 hours so that the visualization reflects more recent blockchain transaction data. Other cache durations (field reports, pools, globe data) remain at 1 hour.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore