### PR TITLE
fix: resolve Vercel runtime timeout on /api/data

### DIFF
--- a/pages/api/cron.ts
+++ b/pages/api/cron.ts
@@ -1,0 +1,48 @@
+/**
+ * Cron endpoint to pre-warm caches
+ * Scheduled via vercel.json to run every 6 hours
+ */
+
+import { cacheWithExpiry } from "@utils/cache";
+import { fetchGraphData, fetchGlobeData } from "@lib/api/data-service";
+import {
+  CACHE_KEY,
+  CACHE_TTL_SECONDS,
+  GLOBE_CACHE_KEY,
+  GLOBE_CACHE_TTL_SECONDS,
+} from "@config/cache";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const authHeader = req.headers.authorization;
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  try {
+    await Promise.all([
+      cacheWithExpiry(CACHE_KEY, CACHE_TTL_SECONDS, fetchGraphData, true),
+      cacheWithExpiry(
+        GLOBE_CACHE_KEY,
+        GLOBE_CACHE_TTL_SECONDS,
+        fetchGlobeData,
+        true
+      ),
+    ]);
+
+    return res.status(200).json({ ok: true });
+  } catch (error) {
+    console.error("Cron cache warm failed:", error);
+    return res.status(500).json({
+      error: "Cache warm failed",
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export const config = {
+  maxDuration: 120,
+};

--- a/pages/api/data.ts
+++ b/pages/api/data.ts
@@ -36,6 +36,7 @@ export default async function handler(
 }
 
 export const config = {
+  maxDuration: 60,
   api: {
     responseLimit: false,
   },

--- a/pages/api/geo.ts
+++ b/pages/api/geo.ts
@@ -37,6 +37,7 @@ export default async function handler(
 }
 
 export const config = {
+  maxDuration: 60,
   api: {
     responseLimit: false,
   },


### PR DESCRIPTION
## Description

The `/api/data` and `/api/geo` routes were timing out after 15 seconds on Vercel when the Redis cache was cold. Two issues caused this: no `maxDuration` was configured on the API routes, and the cron endpoint referenced in `vercel.json` (`/api/cron`) didn't exist, so the cache was never pre-warmed. This PR adds `maxDuration: 60` to both data-serving routes and creates the missing cron endpoint that refreshes both caches every 6 hours.

**Note:** A `CRON_SECRET` environment variable is required in Vercel for cron auth (automatically set on Pro plans).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore