### PR TITLE
fix: extend API timeouts and warm caches hourly to prevent /api/data timeouts

### DIFF
--- a/config/cache.ts
+++ b/config/cache.ts
@@ -3,7 +3,7 @@
  */
 
 export const CACHE_KEY = "graph-data-3";
-export const CACHE_TTL_SECONDS = 3600 * 6; // 6 hours
+export const CACHE_TTL_SECONDS = 3600 * 24; // 24 hours
 
 // Field reports cache
 export const REPORTS_CACHE_KEY = "field-reports-1";
@@ -15,7 +15,7 @@ export const POOLS_CACHE_TTL_SECONDS = 3600; // 1 hour
 
 // Globe data cache
 export const GLOBE_CACHE_KEY = "globe-data-1";
-export const GLOBE_CACHE_TTL_SECONDS = 3600; // 1 hour
+export const GLOBE_CACHE_TTL_SECONDS = 3600 * 24; // 24 hours
 
 // SWR configuration
 export const SWR_REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes

--- a/pages/api/cron.ts
+++ b/pages/api/cron.ts
@@ -44,5 +44,5 @@ export default async function handler(
 }
 
 export const config = {
-  maxDuration: 120,
+  maxDuration: 300,
 };

--- a/pages/api/data.ts
+++ b/pages/api/data.ts
@@ -36,7 +36,7 @@ export default async function handler(
 }
 
 export const config = {
-  maxDuration: 60,
+  maxDuration: 300,
   api: {
     responseLimit: false,
   },

--- a/pages/api/geo.ts
+++ b/pages/api/geo.ts
@@ -37,7 +37,7 @@ export default async function handler(
 }
 
 export const config = {
-  maxDuration: 60,
+  maxDuration: 300,
   api: {
     responseLimit: false,
   },

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron",
-      "schedule": "0 */6 * * *"
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Description

`/api/data` was still hitting Vercel's 60s timeout when serving cold-cache requests. The fresh fetch genuinely takes longer than 60s, and the cache TTL (6h) matched the cron interval (6h), so there was always a window where the cache expired before the next warm-up — forcing user requests to do the cold fetch.

This PR bumps `maxDuration` on `/api/data`, `/api/geo`, and `/api/cron` to 300s (Vercel's new default max on all plans), switches the cache-warm cron to run hourly instead of every 6 hours, and extends the graph + globe cache TTLs to 24 hours so the cache always outlives the cron interval and users never block on a cold fetch.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)