### PR TITLE
Exclude CELO token transfers from graph data

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -5,6 +5,9 @@
 // External addresses
 export const FAUCET_ADDRESS = "0x5523058cdFfe5F3c1EaDADD5015E55C6E00fb439";
 
+// CELO native token (ERC20) contract on Celo mainnet — excluded from graph data
+export const CELO_TOKEN_ADDRESS = "0x471EcE3750Da237f93B8E339c536989b8978a438";
+
 // External URLs
 export const CELOSCAN_BASE_URL = "https://celoscan.io";
 export const SARAFU_NETWORK_BASE_URL = "https://sarafu.network";

--- a/config/index.ts
+++ b/config/index.ts
@@ -5,6 +5,7 @@
 // Application constants
 export {
   FAUCET_ADDRESS,
+  CELO_TOKEN_ADDRESS,
   CELOSCAN_BASE_URL,
   SARAFU_NETWORK_BASE_URL,
   TWO_MONTHS_MS,

--- a/lib/api/queries/transactions.ts
+++ b/lib/api/queries/transactions.ts
@@ -3,7 +3,11 @@
  */
 
 import { federatedDB } from "@db/db";
-import { FAUCET_ADDRESS, ONE_YEAR_MS } from "@/config/constants";
+import {
+  CELO_TOKEN_ADDRESS,
+  FAUCET_ADDRESS,
+  ONE_YEAR_MS,
+} from "@/config/constants";
 
 /**
  * Fetch transactions from the database
@@ -31,6 +35,11 @@ export function fetchTransactions() {
     .where("chain_data.tx.success", "=", true)
     .where("chain_data.token_transfer.sender_address", "!=", FAUCET_ADDRESS)
     .where("chain_data.token_transfer.recipient_address", "!=", FAUCET_ADDRESS)
+    .where(
+      "chain_data.token_transfer.contract_address",
+      "!=",
+      CELO_TOKEN_ADDRESS
+    )
     .where(
       "chain_data.tx.date_block",
       ">=",


### PR DESCRIPTION
## Description

Filters out transfers of the CELO native ERC20 token (`0x471EcE3750Da237f93B8E339c536989b8978a438`) at the transaction query level so they no longer appear in the network graph or globe visualizations. Adds a `CELO_TOKEN_ADDRESS` constant in `config/constants.ts` and applies a `contract_address != CELO_TOKEN_ADDRESS` filter in `fetchTransactions`, which is shared by both `fetchGraphData` and `fetchGlobeData`. Pool swap transactions are unaffected.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)